### PR TITLE
fix(verify): MSVC C23 gate + graceful degradation; repair CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -62,10 +62,15 @@ jobs:
           unzip -q nim.zip
           echo "$PWD/nim-2.2.0/bin" >> "$GITHUB_PATH"
 
+      # Fixtures mirror the nimble `test` task: testlib (explicit-pattern block),
+      # libmagic (bare logical name "magic"), and libvern.so.3 (Linux runtime-only
+      # versioned soname). Without these the dynlib "magic"/"vern" tests fail.
       - name: Build test library (MSVC)
         if: matrix.cc == 'vcc'
         shell: cmd
-        run: cl /LD /DTESTLIB_BUILDING /Fe:tests\testlib.dll tests\testlib.c
+        run: |
+          cl /LD /DTESTLIB_BUILDING /Fe:tests\testlib.dll tests\testlib.c
+          cl /LD /DTESTLIB_BUILDING /Fe:tests\libmagic.dll tests\testlib.c
 
       - name: Build test library (GCC/Clang)
         if: matrix.cc != 'vcc'
@@ -73,18 +78,25 @@ jobs:
         run: |
           if [ "$RUNNER_OS" = "Windows" ]; then
             gcc -shared -o tests/testlib.dll tests/testlib.c
+            gcc -shared -o tests/libmagic.dll tests/testlib.c
           elif [ "$RUNNER_OS" = "macOS" ]; then
             cc -shared -fPIC -o tests/libtestlib.dylib tests/testlib.c
+            cc -shared -fPIC -o tests/libmagic.dylib tests/testlib.c
           else
             gcc -shared -fPIC -o tests/libtestlib.so tests/testlib.c
+            gcc -shared -fPIC -o tests/libmagic.so tests/testlib.c
+            gcc -shared -fPIC -o tests/libvern.so.3 tests/testlib.c
           fi
 
+      # /std:clatest opens the C23 gate so MSVC exposes _Generic/__typeof__;
+      # -d:softlinkStrictVerify turns a would-be-skipped verify block into a hard
+      # #error, so this leg cannot go green unless the real check actually compiled.
       - name: Run tests (MSVC)
         if: matrix.cc == 'vcc'
         shell: cmd
         run: |
           set PATH=%CD%\tests;%CD%\nim-2.2.0\bin;%PATH%
-          nim c -r --cc:vcc --path:src --passC:/I. tests\test_softlink.nim
+          nim c -r --cc:vcc --path:src --passC:/I. --passC:/std:clatest -d:softlinkStrictVerify tests\test_softlink.nim
 
       - name: Run tests (GCC/Clang)
         if: matrix.cc != 'vcc'
@@ -97,4 +109,4 @@ jobs:
           elif [ "$RUNNER_OS" = "Windows" ]; then
             export PATH="./tests:$PATH"
           fi
-          nim c -r --path:src --passC:-I. tests/test_softlink.nim
+          nim c -r --path:src --passC:-I. -d:softlinkStrictVerify tests/test_softlink.nim

--- a/src/softlink.nim
+++ b/src/softlink.nim
@@ -275,28 +275,38 @@ proc genVerifyBlock(procs: seq[SoftlinkProc], tag: string): seq[NimNode] =
       emitArray.add(newStrLitNode(
         "),\n  \"" & errMsg & "\"\n);\n"))
 
-      # --- MSVC C path: call + __typeof__ pointer trick ---
-      # For pointer returns, same dereference approach. For void/scalar,
-      # use _Generic + __typeof__ pointer trick. `retIsPointerLike` (set
-      # above for the GCC path) classifies cstring/cstringArray/pointer
-      # alongside nnkPtrTy — same #11 fix applies here.
+      # --- MSVC C path: _Generic + __typeof__ (C23 only) ---
+      # MSVC only exposes _Generic and __typeof__ in C23 mode (/std:clatest), so
+      # gate the whole branch on __STDC_VERSION__ >= C23. In default mode MSVC
+      # doesn't even recognize _Generic — it parses as a call and errors with
+      # C2059/C2275 — so without the gate every pointer-returning proc breaks the
+      # build. Gated, default-mode MSVC instead falls through to the graceful
+      # fallback below (no verification, but the build works). CI forces
+      # /std:clatest + -d:softlinkStrictVerify so the check is genuinely exercised
+      # there and can't be silently skipped (see the fallback). For pointer
+      # returns the same dereference trick as the GCC path strips pointee const;
+      # `retIsPointerLike` classifies cstring/cstringArray/pointer with nnkPtrTy.
       emitArray.add(newStrLitNode(
-        "#elif defined(_MSC_VER)\n"))
+        "#elif defined(_MSC_VER) && defined(__STDC_VERSION__) && __STDC_VERSION__ >= 202311L\n"))
       if retIsPointerLike:
-        # Pointer return: use _Generic on dereferenced __typeof__ to strip const.
-        # (__typeof__(*func(args)))* gives non-const-qualified pointer after
-        # _Generic strips the pointee's top-level const.
-        # Actually, _Generic doesn't strip const — use assignment to a
-        # matching type via __typeof__. MSVC has __typeof__ but not
-        # __builtin_types_compatible_p. Fall back to the exact _Generic check
-        # for MSVC pointer returns (same limitation as before for const returns).
+        # Pointer return: dereference BOTH the return value and the declared
+        # return type inside _Generic. _Generic applies lvalue conversion to its
+        # controlling expression, which drops the pointee's top-level const —
+        # so `*(__typeof__(f()))0` (type `const char`) converts to `char` and
+        # matches the association `__typeof__(*(RET)0)` (`char`). This is the
+        # same const-tolerant trick the GCC path (`__builtin_types_compatible_p`
+        # on dereferenced operands) and the C++ path (`strip_ptr_const`) use, and
+        # it reuses the identical `__typeof__(*(RET)0)` construct emitted above.
+        # Before this, the branch compared `const char**` (from
+        # `(__typeof__(f())*)0`) against `char**` and rejected every
+        # `const char *`-returning proc — e.g. libz3's `Z3_string` (#11 on MSVC).
         emitArray.add(newStrLitNode(
-          "_Static_assert(\n  _Generic((__typeof__("))
+          "_Static_assert(\n  _Generic(*(__typeof__("))
         buildCallArgs(emitArray, p.nameStr, dummyVars)
-        emitArray.add(newStrLitNode(")*)0,\n    "))
+        emitArray.add(newStrLitNode("))0,\n    __typeof__(*("))
         addTypeToEmit(emitArray, p.formalParams[0])
         emitArray.add(newStrLitNode(
-          "*: 1, default: 0),\n  \"" & errMsg & "\"\n);\n"))
+          ")0): 1, default: 0),\n  \"" & errMsg & "\"\n);\n"))
       else:
         # Non-pointer: call + _Generic __typeof__ pointer trick
         buildCallArgs(emitArray, p.nameStr, dummyVars)
@@ -310,9 +320,21 @@ proc genVerifyBlock(procs: seq[SoftlinkProc], tag: string): seq[NimNode] =
         emitArray.add(newStrLitNode(
           "*: 1, default: 0),\n  \"" & errMsg & "\"\n);\n"))
 
-      # --- Fallback ---
-      emitArray.add(newStrLitNode(
-        "#else\n#error \"softlink: header verification requires GCC, Clang, MSVC, or a C++ compiler.\"\n#endif\n"))
+      # --- Fallback: graceful degradation ---
+      # Compile-time signature verification is best-effort: it must never break an
+      # otherwise-valid build. On a compiler/mode lacking the needed features —
+      # notably default-mode MSVC, where _Generic/__typeof__ are unavailable — emit
+      # nothing (the runtime FFI machinery is generated separately and is
+      # unaffected). Opt into a hard error with `-d:softlinkStrictVerify` so a
+      # silently-skipped check can't pass unnoticed; CI sets it (with the std flag
+      # that opens the MSVC gate above) to guarantee the check is exercised.
+      when defined(softlinkStrictVerify):
+        emitArray.add(newStrLitNode(
+          "#else\n#error \"softlink: signature verification unavailable here " &
+          "(need C++, GCC/Clang, or MSVC /std:clatest); remove -d:softlinkStrictVerify to skip\"\n#endif\n"))
+      else:
+        emitArray.add(newStrLitNode(
+          "#else\n/* softlink: signature verification skipped — unsupported compiler/mode */\n#endif\n"))
 
       verifyBody.add(newNimNode(nnkPragma).add(
         newNimNode(nnkExprColonExpr).add(


### PR DESCRIPTION
## What
- **MSVC verify branch** gated on C23 (`__STDC_VERSION__ >= 202311L`) — MSVC only exposes `_Generic`/`__typeof__` under `/std:clatest`. Default-mode MSVC (which errors C2059/C2275 on `_Generic`) now **gracefully degrades** to no verification instead of breaking the build.
- **Const-strip** fix for MSVC pointer returns (dereference both operands like GCC/C++) so `const char *`-returning procs (libz3 `Z3_string`) verify once the gate opens.
- **`-d:softlinkStrictVerify`**: fallback emits nothing by default (best-effort), or a hard `#error` when set — so a silently-skipped check can't pass unnoticed.
- **ci.yaml**: build `libmagic`/`libvern.so.3` fixtures on all legs (fixes the ubuntu/macOS/mingw redness — missing-fixture gap from the magic feature); MSVC leg runs `/std:clatest -d:softlinkStrictVerify` so the C23 gate is opened AND a skip becomes a hard error — **the leg can't go green unless the real check compiled.**

## Verification
- Linux (GCC), strict mode: 51 tests, exit 0 (GCC branch always taken; strict is a no-op there).
- windows-msvc: **this PR's CI is the authoritative check.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)